### PR TITLE
Add logger to context for serverInit

### DIFF
--- a/modelcontextprotocol/mcpserver/protocol.go
+++ b/modelcontextprotocol/mcpserver/protocol.go
@@ -142,7 +142,7 @@ func (m *McpServer) handleIncomingMessage(
 
 func (m *McpServer) EventMcpRequestInitialize(params *mcp.JsonRpcRequestInitializeParams, reqId *jsonrpc.JsonRpcRequestId) {
 	// store client information
-	if params.ProtocolVersion != mcp.ProtocolVersion {
+	if params.ProtocolVersion < mcp.ProtocolVersion {
 		m.logger.Error("protocol version mismatch", types.LogArg{
 			"expected": mcp.ProtocolVersion,
 			"received": params.ProtocolVersion,

--- a/modelcontextprotocol/mcpserver/protocol.go
+++ b/modelcontextprotocol/mcpserver/protocol.go
@@ -147,7 +147,9 @@ func (m *McpServer) EventMcpRequestInitialize(params *mcp.JsonRpcRequestInitiali
 			"expected": mcp.ProtocolVersion,
 			"received": params.ProtocolVersion,
 		})
-		m.jsonRpcTransport.SendError(jsonrpc.RpcInvalidRequest, "protocol version mismatch", reqId)
+
+		s := fmt.Sprintf("protocol version mismatch: expected %s, received %s", mcp.ProtocolVersion, params.ProtocolVersion)
+		m.jsonRpcTransport.SendError(jsonrpc.RpcInvalidRequest, "protocol version mismatch: "+s, reqId)
 		return
 	}
 	// we store the client information
@@ -165,7 +167,8 @@ func (m *McpServer) EventMcpRequestInitialize(params *mcp.JsonRpcRequestInitiali
 				ListChanged: jsonrpc.BoolPtr(true),
 			},
 		},
-		ServerInfo: mcp.ServerInfo{Name: m.serverName, Version: m.serverVersion},
+		ServerInfo:   mcp.ServerInfo{Name: m.serverName, Version: m.serverVersion},
+		Instructions: m.instructions,
 	}
 	m.jsonRpcTransport.SendJsonRpcResponse(&response, reqId)
 }

--- a/modelcontextprotocol/mcpserver/server.go
+++ b/modelcontextprotocol/mcpserver/server.go
@@ -15,6 +15,7 @@ type McpServer struct {
 	logger        types.Logger
 	serverName    string
 	serverVersion string
+	instructions  *string
 	handler       modelcontextprotocol.McpServerEventHandler
 	// used by protocol
 	clientName          string
@@ -55,10 +56,15 @@ func NewMcpSdkServer(serverDefinition types.McpSdkServerDefinition, debug bool) 
 		logger:        logger,
 		serverName:    sdkServerDefinition.ServerName(),
 		serverVersion: sdkServerDefinition.ServerVersion(),
+		instructions:  sdkServerDefinition.Instructions(),
 		handler:       mcpServerNotifications,
 		lastRequestId: 0,
 	}, nil
 
+}
+
+func (mcp *McpServer) Logger() types.Logger {
+	return mcp.logger
 }
 
 func (mcp *McpServer) StdioTransport() types.Transport {

--- a/protocol/mcp/rpcReqInitialize.go
+++ b/protocol/mcp/rpcReqInitialize.go
@@ -18,6 +18,7 @@ type JsonRpcRequestInitializeParams struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    ClientCapabilities `json:"capabilities"`
 	ClientInfo      ClientInfo         `json:"clientInfo"`
+	Instructions    *string            `json:"instructions,omitempty"`
 }
 
 type ClientCapabilities struct {

--- a/protocol/mcp/rpcRespInitialize.go
+++ b/protocol/mcp/rpcRespInitialize.go
@@ -9,11 +9,13 @@ type JsonRpcResponseInitializeResult struct {
 	ProtocolVersion string             `json:"protocolVersion"`
 	Capabilities    ServerCapabilities `json:"capabilities"`
 	ServerInfo      ServerInfo         `json:"serverInfo"`
+	Instructions    *string            `json:"instructions"`
 }
 
 type ServerInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name         string  `json:"name"`
+	Version      string  `json:"version"`
+	Instructions *string `json:"instructions,omitempty"`
 }
 
 type ServerCapabilities struct {
@@ -73,6 +75,14 @@ func ParseJsonRpcResponseInitialize(response *jsonrpc.JsonRpcResponse) (*JsonRpc
 		return nil, err
 	}
 	resp.ServerInfo.Version = version
+
+	// read instructions are present
+	instructions := protocol.GetOptionalStringField(serverInfo, "instructions")
+	if instructions != nil {
+		resp.Instructions = instructions
+	} else {
+		resp.Instructions = nil
+	}
 
 	// read capabilities
 	capabilities, err := protocol.CheckIsObject(result, "capabilities")

--- a/providers/sdk/definition.go
+++ b/providers/sdk/definition.go
@@ -15,6 +15,7 @@ type SdkServerDefinition struct {
 	serverVersion         string
 	debugLevel            string
 	debugFile             string
+	instructions          *string
 	toolConfigurationData interface{}
 	toolsInitFunction     interface{}
 	toolDefinitions       []*SdkToolDefinition
@@ -65,6 +66,10 @@ func (s *SdkServerDefinition) ServerVersion() string {
 	return s.serverVersion
 }
 
+func (s *SdkServerDefinition) Instructions() *string {
+	return s.instructions
+}
+
 func (s *SdkServerDefinition) SetDebugLevel(debugLevel string, debugFile string) {
 	s.debugLevel = debugLevel
 	s.debugFile = debugFile
@@ -85,10 +90,14 @@ func (s *SdkServerDefinition) DebugFile() string {
 	return s.debugFile
 }
 
-func (s *SdkServerDefinition) WithTools(toolConfigurationDate interface{}, toolsInitFunction interface{}) types.ToolsDefinition {
-	s.toolConfigurationData = toolConfigurationDate
+func (s *SdkServerDefinition) WithTools(toolConfigurationData interface{}, toolsInitFunction interface{}) types.ToolsDefinition {
+	s.toolConfigurationData = toolConfigurationData
 	s.toolsInitFunction = toolsInitFunction
 	return s
+}
+
+func (s *SdkServerDefinition) SetInstructions(instructions string) {
+	s.instructions = &instructions
 }
 
 func (s *SdkServerDefinition) AddTool(toolName string, description string, toolHandler interface{}) error {

--- a/providers/sdk/lifecycle.go
+++ b/providers/sdk/lifecycle.go
@@ -12,11 +12,14 @@ func (s *SdkServerDefinition) serverInitFunction(ctx context.Context, logger typ
 	var result interface{}
 	var callErr, err error
 
+	// create a new context with the logger
+	goCtx := types.ContextWithLogger(ctx, logger)
+
 	// check if we have a tool configuration data
 	if s.toolConfigurationData != nil {
-		result, callErr, err = callFunction(s.toolsInitFunction, ctx, s.toolConfigurationData)
+		result, callErr, err = callFunction(s.toolsInitFunction, goCtx, s.toolConfigurationData)
 	} else {
-		result, callErr, err = callFunction(s.toolsInitFunction, ctx)
+		result, callErr, err = callFunction(s.toolsInitFunction, goCtx)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Makes the gomcp server logger available during server init (via the context) - this has a few advantages:

1. The gomcp logger is now available for logging during the setup of the tool context
2. We only need to do logger setup once in the server init
3. Our logs are properly interleaved in the same log as the MCP server


# Logger setup

In our case, the logger setup is configuring the logrus package (https://github.com/sirupsen/logrus) to send logs to the same place as the MCP server.